### PR TITLE
Removed link to the Wiki.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Make robotics and mechatronics accessible to the widest possible audience.
 
 ---
 For more information about the group:
-- [Robots for Kids wiki](https://github.com/ProgrammingRobotsStudyGroup/RobotsForKids/wiki)
 - [Robot Garden Meetups](http://www.meetup.com/Robot-Garden)
 - [Robotics Free Forum](http://prsg.freeforums.org/index.php)
 - [Robot Garden Robotics Wiki](http://www.robotgarden.org/wiki/robotics/)
+- [Commercial Kits and Curricula](https://github.com/merose/RobotsForKids/kits-and-curricula.md)

--- a/kits-and-curricula.md
+++ b/kits-and-curricula.md
@@ -1,0 +1,23 @@
+# Low-Cost Commercial Robots and Kits
+There are many commercial robots that are relatively low cost, oriented around first-time hobbyists. A selected list:
+* DFRobot MiniQ v2 ($79, assembled, includes line following, IR proximity detection, IR remote, light sensing, compass)
+* MakerBlock mBot ($75, kit, includes line following, ultrasonic distance sensor, light sensor, Bluetooth, IR remote)
+* Pololu Zumo ($150, assembled, includes 9DF MMU, encoders, IR proximity sensors, LCD)
+* Pololu 3pi ($112, assembled, includes line following, buzzer, pushbuttons, LCD)
+* Sparkfun Redbot ($85, kit, includes line following, accelerometer)
+* Parallax Boebot for Arduino ($150, kit, includes IR proximity sensors, light sensors, bumpers, curriculum from New Jersey BOE)
+* GoPiGo kit for RPi ($90 + RPi, kit)
+* Finch ($100?, assembled)
+* Arcbotics Sparki ($150, assembled)
+* Parallax Scribbler ($130, assembled, includes line following, light sensing)
+
+And many more, of course.
+
+# Sample Curricula and Activities
+A few samples of curricular material, mostly geared toward middle school.
+* Boebot curricula [at Parallax](http://learn.parallax.com/ShieldRobot) and [at ed4tech.com](http://www.ed4tech.com/exploringrobotics.com/index.php?option=com_content&view=article&id=92&Itemid=266)
+* [Version 3](https://github.com/merose/VMSRobot3) of Mark's robot for Valley Montessori Middle School
+* [Version 2](https://github.com/merose/VMSRobot2) of Mark's robot for Valley Montessori Middle School
+* [NASA Robotics Alliance](http://robotics.nasa.gov/edu/6-8.php), for grades 6-8
+* [CMU Robotics Academy](http://education.rec.ri.cmu.edu/content/curriculum/middle_school/index.htm)
+* [USC K-12 Robotics materials](http://robotics.usc.edu/~agents/k-12/index.php)


### PR DESCRIPTION
Removed links to the Wiki, and added info from the Wiki home page to a
new “kits and curricula” page, in preparation for removing the single existing
Wiki page.
